### PR TITLE
Don't perform trailing slash rewrite when target is directory

### DIFF
--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -22,7 +22,10 @@ http {
     index index.html;
     root /app/_site;
 
-    rewrite \/(.*)\/$ /$1 permanent;
+    if (!-d $request_filename) {
+      rewrite \/(.*)\/$ /$1 permanent;
+    }
+    
     try_files $uri $uri.html $uri/ =404;
   }
 }


### PR DESCRIPTION
I messed something up in the last pull request.
Before nginx would redirect every time there was a trailing slash detected on the request url. But this caused an infinite redirect loop on folders. This pull request fixes that.

Try going to the `/about/` folder on a site using the code of the previous commit, it will be stuck in a redirect loop.
