### PR TITLE
Fix Jekyll UTF-8 building bug

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -80,6 +80,12 @@ if [ ! -f $BUILD_DIR/.gems/bin/jekyll ]; then
     fi
 fi
 
+# Set charset to avoid https://github.com/jekyll/jekyll/issues/4268
+echo "-----> Setting UTF-8 environment"
+export LC_ALL=C.UTF-8
+export LANG=en_US.UTF-8
+export LANGUAGE=en_US.UTF-8
+
 echo "-----> Building Jekyll site"
 cd $BUILD_DIR
 


### PR DESCRIPTION
Building certain SASS sites seems to crash the build process due to missing UTF8 environment variables. This commit fixes that issue.

See: https://github.com/jekyll/jekyll/issues/4268
