### PR TITLE
Fix error due to Ruby version being < 2.0.0.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,6 +27,7 @@ if [[ `ruby -v` == "ruby 1"* ]]; then
   rbenv download 2.2.1
   rbenv rehash
   rbenv local 2.2.1
+  rbenv global 2.2.1
 else
   echo "-----> Using `ruby -v`"
 fi


### PR DESCRIPTION
When installing building my Jekyll page on Ubuntu 16.04 it crashes due to:

```
-----> Building Jekyll site
       Fetching gem metadata from http://rubygems.org/...........
       RubyGems 1.8.23 is not threadsafe, so your gems will be installed one at a time. Upgrade to RubyGems 2.1.0 or higher to enable parallel gem installation.
       Fetching rake 12.3.0
       Installing rake 12.3.0
       Gem::InstallError: rake requires Ruby version >= 2.0.0.
       An error occurred while installing rake (12.3.0), and Bundler cannot continue.
       Make sure that `gem install rake -v '12.3.0'` succeeds before bundling.

       In Gemfile:
       rake
```

To me this seems to be because the system version of Ruby is used and not the rbenv version.

As a fix I just added `rbenv global <version>` and that fixes the issue for me.