### PR TITLE
Serve index.htm and index.xml files when appropriate

### DIFF
--- a/conf/nginx.conf.erb
+++ b/conf/nginx.conf.erb
@@ -19,7 +19,7 @@ http {
   server {
     listen <%= ENV["PORT"] %>;
 
-    index index.html;
+    index index.html index.htm index.xml;
     root /app/_site;
 
     if (!-d $request_filename) {


### PR DESCRIPTION
Per #15, adds support for using `.htm` and `.xml` files as indexes to folders. This allows users to have a `/feed` path to their xml feed.