### PR TITLE
force older version of liquid

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -53,10 +53,10 @@ if [ ! -f $BUILD_DIR/.gems/bin/jekyll ]; then
     echo "Jekyll not found!"
     echo "-----> Installing Jekyll"
 
-    # Newer versions depend on ruby_dep which needs newer ruby versions
+    # Newer versions depend on newer ruby versions
     gem install listen -v "< 3.1" --no-rdoc --no-ri | indent
-
-    gem install liquid --no-rdoc --no-ri | indent
+    gem install liquid -v "< 5.0" --no-rdoc --no-ri | indent
+    
     gem install jekyll redcarpet sass --no-rdoc --no-ri | indent
     gem install therubyracer --no-rdoc --no-ri | indent
 


### PR DESCRIPTION
Error:

```
-----> Cleaning up...
-----> Building blog from herokuish...
-----> Adding BUILD_ENV to build environment...
-----> Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
       Detected buildpacks: multi ruby
-----> Multipack app detected
=====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-nginx.git
=====> Detected Framework: nginx-buildpack
       ./
       ./nginx
       ./mime.types
       ./nginx-debug
-----> nginx-buildpack: Installed nginx/1.9.5 to app/bin
-----> nginx-buildpack: Added start-nginx to app/bin
-----> nginx-buildpack: Added start-nginx-debug to app/bin
-----> nginx-buildpack: Added start-nginx-solo to app/bin
-----> nginx-buildpack: Default mime.types copied to app/config/
-----> nginx-buildpack: Default config copied to app/config.
=====> Downloading Buildpack: https://github.com/inket/dokku-buildpack-jekyll3-nginx.git
=====> Detected Framework: Jekyll
-----> Using ruby 2.3.1p112 (2016-04-26) [x86_64-linux-gnu]
-----> Using default nginx.conf.erb
-----> Using default mime.types
       Jekyll not found!
-----> Installing Jekyll
       Building native extensions.  This could take a while...
       Successfully installed ffi-1.14.2
       Successfully installed rb-inotify-0.10.1
       Successfully installed rb-fsevent-0.10.4
       Successfully installed listen-3.0.8
       4 gems installed
remote: ERROR:  Error installing liquid:
remote: 	liquid requires Ruby version >= 2.5.0.
```