### PR TITLE
Build in production mode

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -68,6 +68,7 @@ echo "-----> Setting UTF-8 environment"
 export LC_ALL=C.UTF-8
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US.UTF-8
+export JEKYLL_ENV=production
 
 echo "-----> Building Jekyll site"
 cd $BUILD_DIR


### PR DESCRIPTION
Jekyll builds in development mode by default. Some plugins don't function properly unless in production mode.

http://jekyllrb.com/docs/configuration/environments/